### PR TITLE
PROJ: gui-extra: brave-browser 1.34.80-1 (new)

### DIFF
--- a/gui-extra/brave-browser/Pkgfile
+++ b/gui-extra/brave-browser/Pkgfile
@@ -1,0 +1,26 @@
+PKGMK_KEEP_SOURCES="no"
+
+name=brave-browser
+description="The web browser from Brave Browse faster by blocking ads and trackers."
+version="1.34.80"
+url="https://brave.com/"
+packager="Sundev79 <sundev79@nutdevs.org>"
+
+run=(make-ca ttf-liberation dejavu-ttf)
+
+source=(https://github.com/brave/brave-browser/releases/download/v1.34.80/brave-browser_1.34.80_amd64.deb)
+
+build() {
+	tar -xf data.tar.xz -C "$PKG/"
+	
+	# Icons
+  for i in 16 24 32 48 64 128 256; do
+    install -Dm644 "$PKG"/opt/brave.com/brave/product_logo_${i/x*}.png \
+                   "$PKG"/usr/share/icons/hicolor/$i/apps/brave-browser.png
+  done
+
+  sed -i "/Exec=/i\StartupWMClass=Brave" "$PKG"/usr/share/applications/brave-browser.desktop
+
+  rm -r "$PKG"/etc/cron.daily/ "$PKG"/opt/brave.com/brave/cron/
+  rm "$PKG"/opt/brave.com/brave/product_logo_*.png
+}


### PR DESCRIPTION
## PROJ: gui-extra: brave-browser 1.34.80-1 (new)
> A web browser that stops ads and trackers by default
