### PR TITLE
brave-browser 1.34.81-1

### DIFF
--- a/gui-extra/brave-browser/Pkgfile
+++ b/gui-extra/brave-browser/Pkgfile
@@ -2,14 +2,14 @@ PKGMK_KEEP_SOURCES="no"
 
 name=brave-browser
 description="The web browser from Brave Browse faster by blocking ads and trackers."
-version="1.34.80"
-release=2
+version="1.34.81"
+release=1
 url="https://brave.com/"
 packager="Sundev79 <sundev79@nutdevs.org>"
 
 run=(make-ca ttf-liberation dejavu-ttf)
 
-source=(https://github.com/brave/brave-browser/releases/download/v1.34.80/brave-browser_1.34.80_amd64.deb)
+source=(https://github.com/brave/brave-browser/releases/download/v$version/brave-browser_${version}_amd64.deb)
 
 build() {
 	tar -xf data.tar.xz -C "$PKG/"

--- a/gui-extra/vscode/Pkgfile
+++ b/gui-extra/vscode/Pkgfile
@@ -4,9 +4,9 @@ url="https://code.visualstudio.com/"
 packager="spiky <spiky@nutyx.org>"
 
 name=vscode
-version=1.62.3
+version=1.63.2
 
-source=(https://az764295.vo.msecnd.net/stable/ccbaa2d27e38e5afa3e5c21c1c7bef4657064247/code_1.62.3-1637137107_amd64.deb)
+source=(https://az764295.vo.msecnd.net/stable/899d46d82c4c95423fb7e10e68eba52050e30ba3/code_1.63.2-1639562499_amd64.deb)
 
 build() {
    tar -xf data.tar.xz -C "$PKG/"


### PR DESCRIPTION
## brave-browser 1.34.81-1
> - Removed requests to https://ftx.com at startup without user opt-in. (#20501)
> - Fixed trailing zeros being incorrectly removed in certain cases. (#20402)
> - Fixed brave://settings/ipfs/keys loading blank page in certain cases. (#20341)
> - Upgraded Chromium to 97.0.4692.99. (#20553) (Changelog for 97.0.4692.99)

## vscode 1.63.2-1
> - Update 1.63.2: The update addresses these [issues](https://github.com/microsoft/vscode/issues?q=is%3Aissue+milestone%3A%22November+2021+Recovery+2%22+is%3Aclosed).