### PR TITLE
xiccd 0.3.0

### DIFF
--- a/cli/xiccd/Pkgfile
+++ b/cli/xiccd/Pkgfile
@@ -1,0 +1,34 @@
+# Description of the package 
+description="X color profile daemon. A simple bridge between colord and X."
+
+# Self-promotion
+packager="hakerdefo"
+
+# Build dependencies
+makedepends=(xorg-libxdmcp xorg-libxau libxcb xorgproto xorg-libx11 m4 xorg-libxrandr colord glib xorg-libxext xorg-libxrender pcre libffi gvfs util-linux)
+
+# Runtime dependencies
+run=(colord)
+
+# Name of the package
+name=xiccd
+
+# Version of the package
+version=0.3.0
+
+# Release of the package
+release=1
+
+# Location of the sources of the package to be built
+source=(https://github.com/agalakhov/${name}/archive/refs/tags/v${version}.tar.gz)
+
+# Recipe for building the package
+build() {
+cd $name-$version
+aclocal
+autoconf
+automake --add-missing --foreign
+./configure --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --sysconfdir=/etc
+make
+make DESTDIR=$PKG install
+}


### PR DESCRIPTION
Adding xiccd version 0.3.0 to NuTyX testing branch. xiccd is a X color profile daemon. A simple bridge between colord and X.