### PR TITLE
Create broadcom-wl modules post-install script

### DIFF
--- a/base/broadcom-wl-kernel/broadcom-wl-kernel.post-install
+++ b/base/broadcom-wl-kernel/broadcom-wl-kernel.post-install
@@ -1,0 +1,1 @@
+depmod -A

--- a/cli-extra/broadcom-wl-kernel-414/broadcom-wl-kernel-414.post-install
+++ b/cli-extra/broadcom-wl-kernel-414/broadcom-wl-kernel-414.post-install
@@ -1,0 +1,1 @@
+depmod -A

--- a/cli-extra/broadcom-wl-kernel-419/broadcom-wl-kernel-419.post-install
+++ b/cli-extra/broadcom-wl-kernel-419/broadcom-wl-kernel-419.post-install
@@ -1,0 +1,1 @@
+depmod -A

--- a/cli-extra/broadcom-wl-kernel-49/broadcom-wl-kernel-49.post-install
+++ b/cli-extra/broadcom-wl-kernel-49/broadcom-wl-kernel-49.post-install
@@ -1,0 +1,1 @@
+depmod -A

--- a/cli-extra/broadcom-wl-kernel-510/broadcom-wl-kernel-510.post-install
+++ b/cli-extra/broadcom-wl-kernel-510/broadcom-wl-kernel-510.post-install
@@ -1,0 +1,1 @@
+depmod -A

--- a/cli-extra/broadcom-wl-kernel-515/broadcom-wl-kernel-515.post-install
+++ b/cli-extra/broadcom-wl-kernel-515/broadcom-wl-kernel-515.post-install
@@ -1,0 +1,1 @@
+depmod -A

--- a/cli-extra/broadcom-wl-kernel-54/broadcom-wl-kernel-54.post-install
+++ b/cli-extra/broadcom-wl-kernel-54/broadcom-wl-kernel-54.post-install
@@ -1,0 +1,1 @@
+depmod -A

--- a/cli-extra/broadcom-wl-kernel-mainline/broadcom-wl-kernel-mainline.post-install
+++ b/cli-extra/broadcom-wl-kernel-mainline/broadcom-wl-kernel-mainline.post-install
@@ -1,0 +1,1 @@
+depmod -A


### PR DESCRIPTION
Post-install scripts use depmod -A to update kernel modules config to add broadcom-wl module