### PR TITLE
Update Pkgfile

### DIFF
--- a/cli/aspell-dict/Pkgfile
+++ b/cli/aspell-dict/Pkgfile
@@ -18,7 +18,7 @@ pt_ver=0.50-2
 nn_ver=0.50.1-1
 da_ver=0.50.1-0
 sv_ver=0.51-0
-en_ver=0.51-1
+en_ver=2020.12.07-0
 
 source=(https://ftp.gnu.org/gnu/aspell/dict/fr/aspell-fr-${fr_ver}.tar.bz2
 	https://ftp.gnu.org/gnu/aspell/dict/de/aspell-de-${de_ver}.tar.bz2
@@ -29,7 +29,7 @@ source=(https://ftp.gnu.org/gnu/aspell/dict/fr/aspell-fr-${fr_ver}.tar.bz2
 	https://ftp.gnu.org/gnu/aspell/dict/pt/aspell-pt-${pt_ver}.tar.bz2
 	https://ftp.gnu.org/gnu/aspell/dict/da/aspell-da-${da_ver}.tar.bz2
 	https://ftp.gnu.org/gnu/aspell/dict/sv/aspell-sv-${sv_ver}.tar.bz2
-	https://ftp.gnu.org/gnu/aspell/dict/en/aspell-en-${en_ver}.tar.bz2
+	https://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-${en_ver}.tar.bz2
 	)
 
 build() {


### PR DESCRIPTION
The english version 0.51-1 is for the aspell version 0.50 and below and is incompatible and doesn't work with aspell version 0.60 and higher. I've updated the package file with correct dictionary version for aspell 0.60 and up. I'm not sure about the rest of the languages. For clarification, you can consult this page,
https://ftp.gnu.org/gnu/aspell/dict/0index.html