### PR TITLE
mesa with libglvnd support

### DIFF
--- a/gui/mesa/Pkgfile
+++ b/gui/mesa/Pkgfile
@@ -9,19 +9,20 @@ contributors="Pierre,Rems,Spiky,Tnut"
 makedepends=(xorgproto pkg-config libtool xorg-xrandr wayland python-mako
              wayland-protocols xorg-libx11 xorg-libdrm xorg-libxext
              xorg-libxdamage expat llvm elfutils xorg-libxshmfence
-             libva libvdpau valgrind lm-sensors xorg-libxvmc libunwind vulkan-icd-loader)
+             libva libvdpau valgrind lm-sensors xorg-libxvmc libunwind vulkan-icd-loader libglvnd)
 
 alias=(xorg-mesa Mesa mesa3d Mesa3D mesa3)
 
 name=mesa
 version=22.1.1
+release=2
 
 source=(add_xdemos-1.patch
 	https://mesa.freedesktop.org/archive/mesa-$version.tar.xz)
 
 build() {
 cd mesa-$version
-patch -Np1 -i ../add_xdemos-1.patch
+#patch -Np1 -i ../add_xdemos-1.patch
 
 mkdir build
 cd    build
@@ -30,8 +31,6 @@ meson --prefix=/usr                  \
       -Dbuildtype=release            \
       -Dgallium-drivers="nouveau,virgl,r300,r600,radeonsi,svga,swrast,iris,zink,crocus" \
       -Dvulkan-drivers="intel,amd,swrast" \
-      -Dgles1=disabled           \
-      -Dgles2=enabled            \
       -Dgallium-nine=false       \
       -Dgallium-vdpau=true       \
       -Dgallium-va=enabled       \
@@ -39,8 +38,9 @@ meson --prefix=/usr                  \
       -Dosmesa=true              \
       -Dvalgrind=false           \
       -Dlibunwind=false          \
-      -D dri3=enabled            \
-      -D egl=enabled             \
+      -Ddri3=enabled             \
+      -Dglvnd=true               \
+      -Dglx-direct=true          \
       ..
 
 ninja


### PR DESCRIPTION
This is for mesa compiled with libglvnd support. I have commented out the x demos patch as it was making the build fail.