### PR TITLE
Fix emojis in Discord by adding noto-fonts-emoji to the repo

### DIFF
--- a/gui-extra/discord/Pkgfile
+++ b/gui-extra/discord/Pkgfile
@@ -1,11 +1,12 @@
 description="All-in-one voice and text chat for gamers that's free and secure."
 url="https://discordapp.com/"
 
-packager="Tnut <tnut@nutyx.org>"
-contributors="Rems,Sundev79,Spiky"
+packager="Skythrew <mael.guerin@outlook.fr>"
+contributors="Rems,Sundev79,Spiky,Tnut"
 
 name=discord
 version=0.0.22
+release=2
 
 run=(gtk3 libnotify xorg-libxscrnsaver glibc alsa-lib nspr nss pulseaudio noto-fonts-emoji)
 

--- a/gui-extra/discord/Pkgfile
+++ b/gui-extra/discord/Pkgfile
@@ -7,7 +7,7 @@ contributors="Rems,Sundev79,Spiky"
 name=discord
 version=0.0.22
 
-run=(gtk3 libnotify xorg-libxscrnsaver glibc alsa-lib nspr nss pulseaudio)
+run=(gtk3 libnotify xorg-libxscrnsaver glibc alsa-lib nspr nss pulseaudio noto-fonts-emoji)
 
 PKGMK_KEEP_SOURCES="no"
 

--- a/gui/noto-fonts-emoji/Pkgfile
+++ b/gui/noto-fonts-emoji/Pkgfile
@@ -1,0 +1,19 @@
+description='Noto Emoji fonts'
+url='https://github.com/googlefonts/noto-emoji'
+
+packager="Skythrew <mael.guerin@outlook.fr>"
+contributors=""
+
+name=noto-fonts-emoji
+version=2.038
+
+source=(https://github.com/googlefonts/noto-emoji/archive/refs/tags/v2.038.tar.gz)
+
+build() {
+cd noto-emoji-$version
+
+mkdir -p $PKG/usr/share/fonts/noto
+
+install -m644 fonts/NotoColorEmoji.ttf $PKG/usr/share/fonts/noto
+install -Dm644 LICENSE $PKG/usr/share/licenses/noto-emoji/LICENSE
+}


### PR DESCRIPTION
- Add noto-fonts-emoji 2.038
- Fix discord by adding noto-fonts-emoji to its runtime dependencies