### PR TITLE
Add Canon printer driver cups-bjnp

### DIFF
--- a/gui-extra/cups-bjnp/Pkgfile
+++ b/gui-extra/cups-bjnp/Pkgfile
@@ -6,10 +6,11 @@ contributors=""
 
 makedepends=(cups)
 run=()
-set=(printer)
+set=(cups printer)
 
 name=cups-bjnp
 version=2.0.3
+release=2
 
 source=(https://sourceforge.net/projects/$name/files/$name/$version/$name-$version.tar.gz)
 

--- a/gui-extra/cups-bjnp/Pkgfile
+++ b/gui-extra/cups-bjnp/Pkgfile
@@ -1,0 +1,21 @@
+description='CUPS backend for the Canon BJNP network printers'
+url='https://github.com/bitwiseworks/cups-bjnp-os2'
+
+packager="Skythrew <mael.guerin@outlook.fr>"
+contributors=""
+
+makedepends=(cups)
+run=()
+set=(printer)
+
+name=cups-bjnp
+version=2.0.3
+
+source=(https://sourceforge.net/projects/$name/files/$name/$version/$name-$version.tar.gz)
+
+build() {
+cd $name-$version
+./configure --prefix=/usr --disable-Werror
+make
+make DESTDIR=$PKG install
+}

--- a/gui-extra/vscodium/Pkgfile
+++ b/gui-extra/vscodium/Pkgfile
@@ -1,8 +1,8 @@
 description="VS Code without MS branding/telemetry/licensing"
 url="https://vscodium.com/"
 
-packager="spiky <spiky@nutyx.org>"
-contributors="Skythrew,Tnut"
+packager="Skythrew <mael.guerin@outlook.fr>"
+contributors="Skythrew,Tnut,Spiky"
 
 run=(ffmpeg glib nspr gtk3 pango cairo xorg-libx11
      wayland libepoxy fribidi harfbuzz xorg-fontconfig
@@ -14,7 +14,7 @@ run=(ffmpeg glib nspr gtk3 pango cairo xorg-libx11
      cups.lib alsa-lib at-spi2-core)
 
 name=vscodium
-version=1.77.3.23102
+version=1.78.2.23132
 
 source=(https://github.com/VSCodium/vscodium/releases/download/$version/codium_${version}_amd64.deb)
 


### PR DESCRIPTION
This pull request adds the needed driver cups-bjnp to make Canon printers working correctly with their own protocol.