### PR TITLE
Fix system-config-printer

### DIFF
--- a/gui-extra/system-config-printer/Pkgfile
+++ b/gui-extra/system-config-printer/Pkgfile
@@ -1,8 +1,8 @@
 description="A CUPS printer configuration tool and status applet"
 url="https://github.com/zdohnal/system-config-printer"
 
-packager="tnut <tnut@nutyx.org>"
-contributors="Spiky"
+packager="Skythrew <mael.guerin@outlook.fr>"
+contributors="Spiky,Tnut"
 
 makedepends=(docbook-xsl intltool xmlto)
 run=(python-dbus python-gobject python-cairo python-cups python-curl
@@ -12,7 +12,7 @@ set=(cups printer)
 
 name=system-config-printer
 version=1.5.18
-release=3
+release=4
 
 source=(https://github.com/OpenPrinting/$name/releases/download/v$version/$name-$version.tar.xz)
 
@@ -32,5 +32,15 @@ make DESTDIR=$PKG install
 find $PKG -name '*.py' -exec python -mpy_compile {} +
 # Compile *.pyo
 find $PKG -name '*.py' -exec python -O -mpy_compile {} +
+
+PYTHON_VER=$(python -c 'import sys; print(".".join(map(str, sys.version_info[0:2])))')
+
+mv $PKG/usr/lib/python$PYTHON_VER/site-packages/cupshelpers-1.0-py$PYTHON_VER.egg/EGG-INFO/PKG-INFO \
+	$PKG/usr/lib/python$PYTHON_VER/site-packages/cupshelpers-1.0-py$PYTHON_VER.egg-info
+
+mv $PKG/usr/lib/python$PYTHON_VER/site-packages/cupshelpers-1.0-py$PYTHON_VER.egg/cupshelpers \
+	$PKG/usr/lib/python$PYTHON_VER/site-packages/cupshelpers
+
+rm -rf $PKG/usr/lib/python$PYTHON_VER/site-packages/cupshelpers-1.0-*.egg
 
 }


### PR DESCRIPTION
- This pulls request finally allows system-config-printer to work correctly on NuTyX by moving some python files to their good location (especially egginfo and the module itself).