### PR TITLE
Fix GNOME Console font (add the new default Monospaced font "Source Code Pro")

### DIFF
--- a/gui/adobe-source-code-pro-fonts/Pkgfile
+++ b/gui/adobe-source-code-pro-fonts/Pkgfile
@@ -1,5 +1,6 @@
 description='Monospaced font family for user interface and coding environments'
 url='https://adobe-fonts.github.io/source-code-pro/'
+license='SIL Open Font License 1.1'
 
 packager="Skythrew <mael.guerin@outlook.fr>"
 contributors=""
@@ -10,13 +11,10 @@ set=(gnome)
 
 name=adobe-source-code-pro-fonts
 version=2.042
+release=2
 italicver=1.062
 
 source=(https://github.com/adobe-fonts/source-code-pro/releases/download/2.042R-u%2F1.062R-i%2F1.026R-vf/OTF-source-code-pro-${version}R-u_${italicver}R-i.zip https://raw.githubusercontent.com/adobe-fonts/source-code-pro/release/LICENSE.md)
-
-unpack() {
-    unzip  OTF-source-code-pro-${version}R-u_${italicver}R-i.zip 
-}
 
 build() {
 

--- a/gui/adobe-source-code-pro-fonts/Pkgfile
+++ b/gui/adobe-source-code-pro-fonts/Pkgfile
@@ -1,0 +1,28 @@
+description='Monospaced font family for user interface and coding environments'
+url='https://adobe-fonts.github.io/source-code-pro/'
+
+packager="Skythrew <mael.guerin@outlook.fr>"
+contributors=""
+
+makedepends=()
+run=()
+set=(gnome)
+
+name=adobe-source-code-pro-fonts
+version=2.042
+italicver=1.062
+
+source=(https://github.com/adobe-fonts/source-code-pro/releases/download/2.042R-u%2F1.062R-i%2F1.026R-vf/OTF-source-code-pro-${version}R-u_${italicver}R-i.zip https://raw.githubusercontent.com/adobe-fonts/source-code-pro/release/LICENSE.md)
+
+unpack() {
+    unzip  OTF-source-code-pro-${version}R-u_${italicver}R-i.zip 
+}
+
+build() {
+
+cd OTF
+
+install -Dt "$PKG/usr/share/fonts/${name%-fonts}" -m644 *.otf
+install -Dt "$PKG/usr/share/licenses/$name" -m644 ../LICENSE.md
+
+}

--- a/gui/gsettings-desktop-schemas/Pkgfile
+++ b/gui/gsettings-desktop-schemas/Pkgfile
@@ -1,13 +1,14 @@
 description="Shared GSettings schemas for the desktop"
 url="http://www.gnome.org/"
 
-packager="spiky <spiky@nutyx.org>"
-contributors="Pierre,Fanch,Tnut"
+packager="Skythrew <mael.guerin@outlook.fr>"
+contributors="Pierre,Fanch,Tnut,Spiky"
 
-makedepends=(meson ninja intltool glib gobject-introspection perl-xml-parser)
+makedepends=(meson ninja intltool glib gobject-introspection perl-xml-parser adobe-source-code-pro-fonts)
 
 name=gsettings-desktop-schemas
 version=44.0
+release=2
 
 source=(https://gitlab.gnome.org/GNOME/$name/-/archive/$version/$name-$version.tar.gz)
 


### PR DESCRIPTION
This pull request adds the new default Monospaced font of GNOME to the repos. It is required to make GNOME Console and some other apps work correctly.