### PR TITLE
adobe-source-code-pro-fonts 2.042-1

### DIFF
--- a/gui/adobe-source-code-pro-fonts/Pkgfile
+++ b/gui/adobe-source-code-pro-fonts/Pkgfile
@@ -1,0 +1,25 @@
+description='Monospaced font family for user interface and coding environments'
+url='https://adobe-fonts.github.io/source-code-pro/'
+license='SIL Open Font License 1.1'
+
+packager="Skythrew <mael.guerin@outlook.fr>"
+contributors=""
+
+makedepends=()
+run=()
+set=(gnome)
+
+name=adobe-source-code-pro-fonts
+version=2.042
+italicver=1.062
+
+source=(https://github.com/adobe-fonts/source-code-pro/releases/download/2.042R-u%2F1.062R-i%2F1.026R-vf/OTF-source-code-pro-${version}R-u_${italicver}R-i.zip https://raw.githubusercontent.com/adobe-fonts/source-code-pro/release/LICENSE.md)
+
+build() {
+
+cd OTF
+
+install -Dt "$PKG/usr/share/fonts/${name%-fonts}" -m644 *.otf
+install -Dt "$PKG/usr/share/licenses/$name" -m644 ../LICENSE.md
+
+}


### PR DESCRIPTION
This pull requests add the new default Monospaced font of GNOME since version 44 (maybe I'm wrong with the version number but nowadays this is the default Monospaced font).