### PR TITLE
gsettings-desktop-schemas 44.0-2

### DIFF
--- a/gui/gsettings-desktop-schemas/Pkgfile
+++ b/gui/gsettings-desktop-schemas/Pkgfile
@@ -1,13 +1,14 @@
 description="Shared GSettings schemas for the desktop"
 url="http://www.gnome.org/"
 
-packager="spiky <spiky@nutyx.org>"
-contributors="Pierre,Fanch,Tnut"
+packager="Skythrew <mael.guerin@outlook.fr>"
+contributors="Pierre,Fanch,Tnut,Spiky"
 
-makedepends=(meson ninja intltool glib gobject-introspection perl-xml-parser)
+makedepends=(meson ninja intltool glib gobject-introspection perl-xml-parser adobe-source-code-pro-fonts)
 
 name=gsettings-desktop-schemas
 version=44.0
+release=2
 
 source=(https://gitlab.gnome.org/GNOME/$name/-/archive/$version/$name-$version.tar.gz)
 


### PR DESCRIPTION
This pull request updates gsettings-desktop-schemas to add the adobe-source-code-pro-fonts dependency, which is needed by GNOME nowadays.