### PR TITLE
minecraft-launcher 1.0.1221-1

### DIFF
--- a/gui-extra/minecraft-launcher/Pkgfile
+++ b/gui-extra/minecraft-launcher/Pkgfile
@@ -1,0 +1,21 @@
+description='Official Minecraft Launcher'
+url='https://minecraft.net'
+license='All rights reserved'
+
+packager="Skythrew <mael.guerin@outlook.fr>"
+contributors=""
+
+makedepends=()
+run=()
+set=()
+
+name=minecraft-launcher
+version=1.0.1221
+
+source=(https://launcher.mojang.com/download/linux/x86_64/${name}_$version.tar.gz https://launcher.mojang.com/download/$name.svg $name.desktop)
+
+build() {
+  install -Dm644 "minecraft-launcher.svg" "$PKG/usr/share/icons/hicolor/symbolic/apps/minecraft-launcher.svg"
+  install -Dm644 "minecraft-launcher.desktop" "$PKG/usr/share/applications/minecraft-launcher.desktop"
+  install -Dm755 "minecraft-launcher/minecraft-launcher" "$PKG/usr/bin/minecraft-launcher"
+}

--- a/gui-extra/minecraft-launcher/minecraft-launcher.desktop
+++ b/gui-extra/minecraft-launcher/minecraft-launcher.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=Minecraft Launcher
+GenericName=Minecraft Launcher
+Comment=Official Minecraft Launcher
+Exec=minecraft-launcher
+Icon=minecraft-launcher
+Terminal=false
+Categories=Game;Application;
+StartupNotify=true


### PR DESCRIPTION
This pull request adds the official launcher of the well known sandbox game called Minecraft. It's a lot easier to use than the current flatpak app :+1: 